### PR TITLE
always fetch pokemon inventory on first run, parsing changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "express": "^4.14.0",
     "jsonfile": "^2.3.1",
     "lodash": "^4.13.1",
-    "pokemon-go-mitm": "^1.1.0"
+    "pokemon-go-mitm": "^1.2.0"
   }
 }


### PR DESCRIPTION
A couple of changes I made to get this to work for me with the latest Pokemon Go release on iOS 1.0.2:
- Updated pokemon-go-mitm to 1.2.0
- Add a request handler to zero out "last_timestamp_ms" of the GetInventory request (this caused empty inventory to get returned). Added a firstRun check so we don't overload the call or risk getting detected. 
- Some updates to the data model parsing, like using "item_data.pokemon_data" instead of "item_data.pokemon". Would probably be better to check for both for API compatibility. 
- Explicitly set entry.nickname since this was causing an error on the UI side. 
