### PR TITLE
Show nicknames in table

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,9 @@ var server = new PokemonGoMITM({
       });
       if (data != null) {
         entry.pokedex_id = parseInt(data.Number);
-        entry.nickname = data["Name"];
+	if (entry.nickname === undefined) {
+          entry.nickname = data["Name"];
+        }
         entry.type_1 = data["Type I"];
         if (data["Type II"]) entry.type_2 = data["Type II"];
       }


### PR DESCRIPTION
Removes the scrubbing of nicknames, allowing you to see them in the table.
This helps differentiate pokemon with identical CP/HP that have different IVs when choosing what to keep.
