### PR TITLE
Improved the power_quotient calculation (IV_atk has more impact)

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ var server = new PokemonGoMITM({
       if (entry.individual_stamina === undefined) entry.individual_stamina = 0;
       if (entry.individual_attack === undefined)  entry.individual_attack  = 0;
       if (entry.individual_defense === undefined) entry.individual_defense = 0;
-      entry.power_quotient = (entry.individual_stamina + entry.individual_attack + entry.individual_defense) / 45;
+      entry.power_quotient = (entry.individual_stamina + entry.individual_attack*2 + entry.individual_defense) / 60;
       var data = _.find(PokemonData, function (pokemon) {
         return (pokemon.Name.toUpperCase() == entry.pokemon_id || pokemon.AltName == entry.pokemon_id);
       });


### PR DESCRIPTION
`CP = (Base Atk + Atk IV) * (Base Def + Def IV)^0.5 * (Base Stam + Stam IV)^0.5 * Lvl(CPScalar)^2 / 10`
As you can see, the atk iv has more impact on the CP. It's not possible to calculate the perfect percentage without knowing the pokemon base stats, but my improved version is still better than the previous one.
