### PR TITLE
Rewrite sorting to be column-based with asc/desc

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,8 +63,8 @@ var server = new PokemonGoMITM({
       if (data != null) {
         entry.pokedex_id = parseInt(data.Number);
 	      if (entry.nickname === undefined) entry.nickname = data["Name"];
-        entry.type_1 = data["Type I"];
-        if (data["Type II"]) entry.type_2 = data["Type II"];
+        entry.type_1 = data["Type I"] ? data["Type I"][0] : '';
+        entry.type_2 = data["Type II"] ? data["Type II"][0] : '';
       }
       entry.move_1 = formatMoveName(entry.move_1);
       entry.move_2 = formatMoveName(entry.move_2);

--- a/public/assets/css/base.css
+++ b/public/assets/css/base.css
@@ -25,7 +25,16 @@ body {
 .stat {
     text-align: center !important;
 }
-
+  
+.ui.table thead th {
+    cursor: pointer;
+}
+th.active:after {
+    content: '↓';
+}
+th.active.reverseSort:after {
+    content: '↑';
+}
 th.atk {
     background-color: #F08030 !important;
 }

--- a/public/scripts/pokemon-list.js
+++ b/public/scripts/pokemon-list.js
@@ -13,57 +13,45 @@ var PokemonListContainer = React.createClass({
       }.bind(this)
     });
   },
+  customSorts: {
+    // Alias or create custom sort orders here, e.g.
+    //   species: ['pokemon_id', 'nickname +']
+  },
+  defaultSecondarySorts: ['nickname +', 'power_quotient +'],
   setSortType: function(type, data) {
-    this.setState({sort: type});
+    var state = {}, seenProps = {}, sortProps;
 
-    data = data || this.state.data;
-    if (this.state.sort === 'perfect') {
-      data.sort(function (a, b) {
-        if (a.power_quotient > b.power_quotient) {
-          return -1;
-        }
-        if (a.power_quotient < b.power_quotient) {
-          return 1;
-        }
-        return 0;
-      });
-    }
-    else if (this.state.sort === 'species') {
-      data.sort(function (a, b) {
-        if (a.pokedex_id == b.pokedex_id) {
-          if (a.power_quotient > b.power_quotient) {
-            return -1;
-          }
-          if (a.power_quotient < b.power_quotient) {
-            return 1;
-          }
-          return 0;
-        }
-        if (a.pokedex_id > b.pokedex_id) {
-          return 1;
-        }
-        if (a.pokedex_id < b.pokedex_id) {
-          return -1;
-        }
-        return 0;
-      });
-    }
-    else if (this.state.sort === 'cp') {
-      data.sort(function (a, b) {
-        if (a.cp > b.cp) {
-          return -1;
-        }
-        if (a.cp < b.cp) {
-          return 1;
-        }
-        return 0;
-      });
+    state.sortReverse = data
+      ? this.state.sortReverse
+      : this.state.sort === type
+        ? !this.state.sortReverse
+        : false;
+    state.sort = type;
+    state.data = data || this.state.data;
+
+    sortProps = this.customSorts[type] || type;
+
+    if ('string' === typeof sortProps) {
+      sortProps = [sortProps];
     }
 
-    this.setState({data: data});
+    // Concat the sortProps with the defaults, then iterate backwards over the
+    // array to splice out duplicate properties in the case that passed props
+    // are in the defaults
+    sortProps = sortProps.concat(this.defaultSecondarySorts);
+    sortProps.reverse();
+    for (var i = sortProps.length - 1, seenProp; i >= 0; i--) {
+      seenProp = sortProps[i].split(' ')[0];
+      if (seenProps[seenProp]) { sortProps.splice(i, 1); }
+      seenProps[seenProp] = 1;
+    }
+    sortProps.reverse();
+
+    state.data.sort(makeSort(sortProps, state.sortReverse));
+    this.setState(state);
   },
   getInitialState: function() {
-    return {data: [], sort: 'perfect'};
+    return {data: [], sort: 'power_quotient', sortReverse: false};
   },
   componentDidMount: function() {
     this.loadPokemonFromServer();
@@ -72,7 +60,7 @@ var PokemonListContainer = React.createClass({
   render: function() {
     return (
       <div id="pokemonListContainer">
-        <PokemonList data={this.state.data} setSortType={this.setSortType} />
+        <PokemonList data={this.state.data} sort={this.state.sort} sortReverse={this.state.sortReverse} setSortType={this.setSortType} />
       </div>
     );
   }
@@ -87,7 +75,7 @@ var PokemonList = React.createClass({
             <h4 className="ui image header">
               <img className="ui mini rounded image" src={'assets/img/icons/' + pokemon.pokedex_id + '.png'} />
               <div className="content name">
-                {pokemon.nickname || pokemon.pokemon_id.toLowerCase() || ''}
+                {pokemon.nickname || humanizePokemonId(pokemon.pokemon_id)}
                 <div className="sub header">
                   {(Math.round(pokemon.weight_kg * 100) / 100) + "kg, " + (Math.round(pokemon.height_m * 100) / 100) + "m"}
                 </div>
@@ -97,6 +85,7 @@ var PokemonList = React.createClass({
               </div>
             </h4>
           </td>
+          <td className={"stat " + pokemon.pokemon_id}>{humanizePokemonId(pokemon.pokemon_id)}</td>
           <td className={"stat " + pokemon.type_1}>{pokemon.type_1}</td>
           <td className={"stat " + pokemon.type_2}>{pokemon.type_2}</td>
           <td className="stat">{pokemon.cp}</td>
@@ -108,30 +97,34 @@ var PokemonList = React.createClass({
         </tr>
       );
     });
+
+    var thClass = function (prop, extra) {
+      var cssClasses = (extra || '').split(' ');
+
+      if (prop === this.props.sort) {
+        cssClasses.push('active');
+        if (this.props.sortReverse) cssClasses.push('reverseSort');
+      }
+
+      return cssClasses.join(' ');
+    }.bind(this);
+
     return (
       <div className="ui container">
         <h1 id="title">Pokemon GO Optimizer</h1>
-        <button className="ui button white" onClick={() => this.props.setSortType('perfect')}>
-          Perfect
-        </button>
-        <button className="ui button white" onClick={() => this.props.setSortType('species')}>
-          Species
-        </button>
-        <button className="ui button white" onClick={() => this.props.setSortType('cp')}>
-          CP
-        </button>
         <table className="ui celled table">
           <thead>
             <tr>
-              <th>Pokemon</th>
-              <th className="stat">Type 1</th>
-              <th className="stat">Type 2</th>
-              <th className="stat">CP</th>
-              <th className="stat">HP</th>
-              <th className="stat atk">ATK</th>
-              <th className="stat def">DEF</th>
-              <th className="stat sta">STA</th>
-              <th className="stat">Perfect</th>
+              <th className={thClass('nickname')} onClick={() => this.props.setSortType('nickname')}>Pokemon</th>
+              <th className={thClass('pokemon_id', 'stat')} onClick={() => this.props.setSortType('pokemon_id')}>Species</th>
+              <th className={thClass('type_1', 'stat')} onClick={() => this.props.setSortType('type_1')}>Type 1</th>
+              <th className={thClass('type_2', 'stat')} onClick={() => this.props.setSortType('type_2')}>Type 2</th>
+              <th className={thClass('cp', 'stat')} onClick={() => this.props.setSortType('cp')}>CP</th>
+              <th className={thClass('stamina_max', 'stat')} onClick={() => this.props.setSortType('stamina_max')}>HP</th>
+              <th className={thClass('individual_attack', 'stat atk')} onClick={() => this.props.setSortType('individual_attack')}>ATK</th>
+              <th className={thClass('individual_defense', 'stat def')} onClick={() => this.props.setSortType('individual_defense')}>DEF</th>
+              <th className={thClass('individual_stamina', 'stat sta')} onClick={() => this.props.setSortType('individual_stamina')}>STA</th>
+              <th className={thClass('power_quotient', 'stat')} onClick={() => this.props.setSortType('power_quotient')}>Perfect</th>
             </tr>
           </thead>
           <tbody>
@@ -142,6 +135,55 @@ var PokemonList = React.createClass({
     );
   }
 });
+
+
+/**
+ * Creates a sort function for an array of objects by a property or list of
+ * properties in descending order of priority.
+ *
+ * Appending a space and + or - to the property name will result in the property
+ * ignoring the reverse param and always sorting in ascending or descending order.
+ *
+ * @param {string|string[]} props Any number of property names and optional forced sort (+ or -)
+ * @param {boolean} reverse Reverse the sort?  Default `false`
+ */
+function makeSort (props, reverse) {
+  props = 'string' === typeof props ? [props] : props;
+
+  function sortOn (i, a, b) {
+    var propArray = props[i++].split(' ')
+      , prop = propArray[0]
+      , forcedDir = propArray[1]
+      , asc = '+' === forcedDir || reverse && '-' !== forcedDir
+      , result;
+
+    if (a[prop] == b[prop]) {
+      return props[i] ? sortOn(i, a, b) : 0;
+    }
+
+    // default result is descending, if it's been determined that we should
+    // sort 'asc', flip the result.
+    result = a[prop] < b[prop] ? 1 : -1;
+    return asc ? result * -1 : result;
+  }
+
+  return function (a, b) {
+    return sortOn(0, a, b);
+  }
+}
+
+
+/**
+ * Reformats a system pokemon ID to title-like string
+ *
+ * @param {string} id A pokemon ID
+ */
+function humanizePokemonId (id) {
+  return (id || '').split('_').map(function (part) {
+    return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+  }).join(' ');
+}
+
 
 ReactDOM.render(
   <PokemonListContainer url="/api/pokemon" pollInterval={2000} />,

--- a/public/scripts/pokemon-list.js
+++ b/public/scripts/pokemon-list.js
@@ -68,6 +68,7 @@ var PokemonListContainer = React.createClass({
 
 var PokemonList = React.createClass({
   render: function() {
+
     var pokemonNodes = this.props.data.map(function(pokemon) {
       return (
         <tr key={pokemon.id}>
@@ -85,6 +86,7 @@ var PokemonList = React.createClass({
               </div>
             </h4>
           </td>
+          <td className="stat">{formatCaughtTime(pokemon.creation_time_ms)}</td>
           <td className={"stat " + pokemon.pokemon_id}>{humanizePokemonId(pokemon.pokemon_id)}</td>
           <td className={"stat " + pokemon.type_1}>{pokemon.type_1}</td>
           <td className={"stat " + pokemon.type_2}>{pokemon.type_2}</td>
@@ -97,6 +99,22 @@ var PokemonList = React.createClass({
         </tr>
       );
     });
+
+    /**
+     * Reformats a system pokemon ID to title-like string
+     *
+     * @param {string} id A pokemon ID
+     */
+    function humanizePokemonId (id) {
+      return (id || '').split('_').map(function (part) {
+        return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+      }).join(' ');
+    }
+
+    function formatCaughtTime (ms) {
+      var date = new Date(Number(ms));
+      return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
+    }
 
     var thClass = function (prop, extra) {
       var cssClasses = (extra || '').split(' ');
@@ -116,6 +134,7 @@ var PokemonList = React.createClass({
           <thead>
             <tr>
               <th className={thClass('nickname')} onClick={() => this.props.setSortType('nickname')}>Pokemon</th>
+              <th className={thClass('creation_time_ms', 'stat')} onClick={() => this.props.setSortType('creation_time_ms')}>Caught</th>
               <th className={thClass('pokemon_id', 'stat')} onClick={() => this.props.setSortType('pokemon_id')}>Species</th>
               <th className={thClass('type_1', 'stat')} onClick={() => this.props.setSortType('type_1')}>Type 1</th>
               <th className={thClass('type_2', 'stat')} onClick={() => this.props.setSortType('type_2')}>Type 2</th>
@@ -170,18 +189,6 @@ function makeSort (props, reverse) {
   return function (a, b) {
     return sortOn(0, a, b);
   }
-}
-
-
-/**
- * Reformats a system pokemon ID to title-like string
- *
- * @param {string} id A pokemon ID
- */
-function humanizePokemonId (id) {
-  return (id || '').split('_').map(function (part) {
-    return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
-  }).join(' ');
 }
 
 


### PR DESCRIPTION
This PR removes the sort buttons and replaces them with asc/desc flippable sorting for all columns.

It also adds a "Species" (pokemon_id) and "Caught" columns.

I added some sort logic to allow sorting by prioritized lists of properties, so that, for example, you can sort by `type_1` primarily followed by `nickname`, then `power_quotient`, and so on.  Then beyond that, you can specify '+' or '-' to force the direction of sorts regardless of the primary sort direction.

The default sorting uses this logic to sort by the column first, followed by `nickname +`, and `power_quotient +`, meaning it will sort by the column in asc or desc, then always sort secondarily on nickname, then power quotient in ascending order.

This PR is almost entirely client side, but I do adjust the way `type_1` and `type_2` are stored because 1.) in the JSON they're arrays which aren't primitive comparable and 2.) the existing method had set `type_2` to `undefined` if it did not exist, and comparison with a string and `undefined` is always `false`.
