### PR TITLE
Scale Percent CP% starting at 0%

### DIFF
--- a/lib/pokemon.js
+++ b/lib/pokemon.js
@@ -37,7 +37,8 @@ Pokemon.prototype.determineMetadata = function () {
   // determine max cp
   var perfcp = (ba + 15) * Math.pow((bd + 15), 0.5) * Math.pow((bs + 15), 0.5) * (Math.pow(LevelToCPM['40'], 2) / 10);
   var maxcp  = (ba + iva) * Math.pow((bd + ivd), 0.5) * Math.pow((bs + ivs), 0.5) * (Math.pow(LevelToCPM['40'], 2) / 10);
-  this.metadata.pcp = maxcp / perfcp;
+  var mincp  = (ba) * Math.pow((bd), 0.5) * Math.pow((bs), 0.5) * (Math.pow(LevelToCPM['40'], 2) / 10);
+  this.metadata.pcp = (maxcp - mincp) / (perfcp - mincp);
 
   // get moves
   this.metadata.move_1 = _.find(MoveData, {Name: this.data.move_1});


### PR DESCRIPTION
If we do PCP = max_cp / perfect_cp, the percent will skew heavily
towards 100%, especially the stronger the Pokemon species is. If
we limit the calculation to a linear percentage above minimum, however,
the PCP will start at 0% (All IVs 0) and grow to 100% (All IVs 15.)

Use:

pcp = (max_cp - min_cp) / (perf_cp - min_cp);

instead to give a higher resolution on exactly how this pokemon compares
to others within the species.

[Note: this is a suggestion. The current method will have Pokemon with (0,0,0) IVs still showing up to 70-80% on the CP scale, which is misleading at best. This new method will anchor 0 and 100% to more inherently intuitive values.]
