### PR TITLE
Add bower to dev dependencies and remove unnecessary installs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM node
 
 RUN apt-get update -qq
 RUN apt-get install -yqq libprotobuf-dev
-RUN npm install -g --silent bower
-RUN npm install -g --silent gulp
+
+# Setup PATH to prioritize local npm bin ahead of system PATH.
+ENV PATH node_modules/.bin:$PATH
 
 RUN mkdir /code
 WORKDIR /code

--- a/README.md
+++ b/README.md
@@ -19,12 +19,10 @@ brew install node
 brew install git
 brew install pkg-config
 brew install --devel protobuf
-sudo npm install -g bower
-sudo npm install -g gulp
 git clone https://github.com/justinleewells/pogo-optimizer
 cd pogo-optimizer
 npm install
-bower install
+npm run install-libs
 npm start
 ```
 
@@ -36,8 +34,6 @@ Run the commands below for your flavor of choice to get the necessary dependenci
 
 ```
 sudo dnf install nodejs protobuf protobuf-devel npm
-sudo npm install -g bower
-sudo npm install -g gulp
 ```
 
 If your distribution is newer (e.g. F24+), npm is included with nodejs and you won't need both.
@@ -45,7 +41,7 @@ If your distribution is newer (e.g. F24+), npm is included with nodejs and you w
 #### Arch Linux
 
 ```
-sudo pacman -S nodejs protobuf npm bower gulp
+sudo pacman -S nodejs protobuf npm
 ```
 
 #### Deb based (Debian, Ubuntu, Raspbian, et al)
@@ -56,8 +52,6 @@ For Debian stable, you'll need the latest node from sources:
 sudo apt-get install -y curl build-essential libprotobuf-dev git pkg-config
 curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
 sudo apt-get install nodejs
-sudo npm install -g bower
-sudo npm install -g gulp
 
 ```
 
@@ -65,8 +59,6 @@ For Debian testing, you can just get nodejs from the repository:
 
 ```
 sudo apt-get install -y build-essential libprotobuf-dev git pkg-config nodejs
-sudo npm install -g bower
-sudo npm install -g gulp
 ```
 
 #### Common
@@ -77,7 +69,7 @@ After you install the necessary packages, all Linux flavors follow this routine:
 git clone https://github.com/justinleewells/pogo-optimizer
 cd pogo-optimizer
 npm install
-bower install
+npm run install-libs
 npm start
 ```
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "pokemon-go-mitm": "^1.5.0"
   },
   "devDependencies": {
+    "bower": "^1.7.9",
     "gulp": "^3.9.1",
     "gulp-connect": "^4.2.0",
     "gulp-copy": "0.0.2",
@@ -19,6 +20,7 @@
     "rimraf": "^2.5.4"
   },
   "scripts": {
+    "install-libs": "bower install",
     "start": "gulp && node index"
   }
 }


### PR DESCRIPTION
It's unnecessary (and in some cases undesirable) to install a global gulp/bower.  The version of the global dependency may conflict between multiple projects (one project could be built on gulp 3 and another on gulp 2 for instance).  By encouraging use of the locally installed gulp/bower, this reduces the chances of issues with people's environments.  It also makes the setup steps a couple commands shorter :).

I added an install-libs script to npm.  This makes it easy for users to execute bower without having to learn anything about the `PATH` environment variable or how to execute scripts in a hidden relative directory (`node_modules/.bin`).  For the docker setup, however, I did things a cleaner way by adding the full npm packages bin directory to the docker container's path.  This makes it so that any commands provided by the various npm packages can be easily executed.  For example, `docker run -v $(pwd):/code pogo bower install`.
