### PR TITLE
provide ca.crt for androids (in docker container)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,7 @@ RUN GIT_DIR=/tmp bower install --allow-root --silent
 EXPOSE 8081
 EXPOSE 3000
 
-CMD npm start
+CMD npm start& \
+sleep 10; \
+openssl x509 -inform PEM -outform DM -in /code/.http-mitm-proxy/certs/ca.pem -out /code/.http-mitm-proxy/certs/ca.crt; \
+sleep infinity


### PR DESCRIPTION
This generates `ca.crt` (required for some/all? android phones) into the container 10 seconds after the container is started so that it can be downloaded just like `ca.pem` is.
See https://github.com/justinleewells/pogo-optimizer/issues/104 (and several other issues apparently)
