### PR TITLE
Generate .http-mitm-proxy certificates in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ COPY .bowerrc /code/
 COPY bower.json /code/
 RUN GIT_DIR=/tmp bower install --allow-root --silent
 
+# Generate .http-mitm-proxy
+RUN ["node", "-e", "require('http-mitm-proxy')().listen({}, function () {process.exit();});"]
+
 COPY . /code/
 
 EXPOSE 8081


### PR DESCRIPTION
This runs `node -e "require('http-mitm-proxy')().listen({}, function () {process.exit();});"` (a little hacky)
Which starts an `http-mitm-proxy` and exiting to create the `.http-mitm-proxy` files.

Not sure if this approach is something we want, but this would mean the layer would be cached as long as we are still using the previous layers were untouched.
