### PR TITLE
Add a docker-compose configuration for easier setup.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "2"
+services:
+  pogo-optimizer:
+    build:
+      context: .
+    ports:
+      - "3000:3000"
+      - "8081:8081"
+    volumes:
+      - ./.http-mitm-proxy:/code/.http-mitm-proxy


### PR DESCRIPTION
This provides a way of starting it with docker without using the long `docker run` command.  Instead, if the user has docker-compose installed, they can just run `docker-compose up` to start the service.

This also starts the container with a data volume for the http-mitm-proxy certs so that they will be stored on the host in the normal location (`.http-mitm-proxy`) and persist from one container to the next, even across image updates.
