### PR TITLE
Updated special Blastoise Water Gun move power to reflect recent change

### DIFF
--- a/data/game/moves.json
+++ b/data/game/moves.json
@@ -2256,7 +2256,7 @@
   {
     "AnimationId": 4,
     "Type": "WATER",
-    "Power": 10,
+    "Power": 6,
     "AccuracyChance": 1,
     "StaminaLossScalar": 0.01,
     "TrainerLevelMin": 1,


### PR DESCRIPTION
One more move update
`WATER_GUN_FAST_BLASTOISE` `Power: 10` -> `Power: 6`
